### PR TITLE
fix bug #19

### DIFF
--- a/src/main/kotlin/com/icecreamqaq/yuq/mirai/MiraiBot.kt
+++ b/src/main/kotlin/com/icecreamqaq/yuq/mirai/MiraiBot.kt
@@ -433,7 +433,16 @@ open class MiraiBot : YuQ, ApplicationService, User {
             val group = this@MiraiBot.groups[group.id] ?: return@subscribeAlways
             this@MiraiBot.groups.remove(group.id)
             eventBus.post(
-                    if (this is BotLeaveEvent.Kick) BotLevelGroupEvent.Kick(group.get(operator.id))
+                    if (this is BotLeaveEvent.Kick) {
+                        // 过滤群匿名和坦白说
+                        when (operator.id) {
+                            // 坦白说
+                            50000000L -> BotLevelGroupEvent.Level(group)
+                            // 群匿名
+                            80000000L -> BotLevelGroupEvent.Level(group)
+                            else -> BotLevelGroupEvent.Kick(group[operator.id])
+                        }
+                    }
                     else BotLevelGroupEvent.Level(group)
             )
         }


### PR DESCRIPTION
在GroupMessage注入中，会根据发消息人的QQ号在群内找到该用户, 但匿名和坦白说的qq号在群内是不可能存在的. 
有两种修改方案，一个是在groups.get()时，判断如果是匿名或坦白说就返回一个特定的对象；另一种是修改事件中的行为。
本pull request 采用了第二种方案。